### PR TITLE
Fix travis script to account for builds that are not on the master repo

### DIFF
--- a/test/db-upgrade-test.rkt
+++ b/test/db-upgrade-test.rkt
@@ -21,6 +21,9 @@
 (define test-dir "./test-db")
 
 (define (candidate-databases)
+  ;; Ensure that test-db directory exists (in case the download database
+  ;; script failed to run
+  (make-directory* test-dir)
   (for/list ([path (in-directory test-dir)]
              #:when (let-values (([base name _] (split-path path)))
                       (regexp-match #rx"^al2-v[0-9]+\\.db$" name)))

--- a/test/download-test-db.sh
+++ b/test/download-test-db.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
+set -e
+
+# The decryption password does not seem to be set on builds that don't run off
+# master. This is probably a good idea, however we need to make sure the build
+# can handle this.
+if [ -z $TESTDBPW ]; then
+    echo "Not downloading test databases, database upgrade tests will not run"
+    exit 0
+fi
+
 # NOTE: this script runs from the root of the repository.  This needs to be
 # accounted for in the file paths
 
-set -e
 file_id=0B5h4XOdkim72cDJ4Z2RZR05UOFE
 file_name=test-db.tar.gz.enc
 file_name2=test-db.tar.gz


### PR DESCRIPTION
Travis will not set the database decryption password on builds that are not
from the master repository.  This was not accounted for in the download script
and it failed.